### PR TITLE
common: Fix Shadowed Errors

### DIFF
--- a/common/email.go
+++ b/common/email.go
@@ -65,12 +65,13 @@ func SendEmail(email, subject, msg string) (err error) {
 	body += "\r\n" + msg
 
 	var c *smtp.Client
+	var conn *tls.Conn
 	if Config.SMTPEnableTLS {
 		tlsconfig := &tls.Config{
 			InsecureSkipVerify: true,
 			ServerName:         Config.SMTPServer,
 		}
-		conn, err := tls.Dial("tcp", Config.SMTPServer+":"+Config.SMTPPort, tlsconfig)
+		conn, err = tls.Dial("tcp", Config.SMTPServer+":"+Config.SMTPPort, tlsconfig)
 		if err != nil {
 			LogWarning(err)
 			return err

--- a/common/search.go
+++ b/common/search.go
@@ -105,7 +105,7 @@ func (s *SQLSearcher) Query(q string, zones []int) (ids []int, err error) {
 
 		acc := qgen.NewAcc()
 		stmt := acc.RawPrepare("SELECT `topics`.`tid` FROM `topics` INNER JOIN `replies` ON `topics`.`tid` = `replies`.`tid` WHERE (MATCH(`topics`.`title`) AGAINST (? IN NATURAL LANGUAGE MODE) OR MATCH(`topics`.`content`) AGAINST (? IN NATURAL LANGUAGE MODE) OR MATCH(`replies`.`content`) AGAINST (? IN NATURAL LANGUAGE MODE)) AND `topics`.`parentID` IN(" + zList + ");")
-		err := acc.FirstError()
+		err = acc.FirstError()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This fixes two error variables in the `common` package that were being redefined inside `if` blocks and not making it out to the `if err != nil...` error handling.