### PR TITLE
router_gen: Remove Unused Functions

### DIFF
--- a/router_gen/route_impl.go
+++ b/router_gen/route_impl.go
@@ -93,14 +93,6 @@ func MView(fname string, path string, args ...string) *RouteImpl {
 	return route
 }
 
-func MemberView(fname string, path string, args ...string) *RouteImpl {
-	route := route(fname, path, false, false, args...)
-	if !route.hasBefore("SuperModOnly", "AdminOnly") {
-		route.Before("MemberOnly")
-	}
-	return route
-}
-
 func ModView(fname string, path string, args ...string) *RouteImpl {
 	route := route(fname, path, false, false, args...)
 	if !route.hasBefore("AdminOnly") {


### PR DESCRIPTION
This removes two unused functions from `router_gen`.